### PR TITLE
Refactor weight structure

### DIFF
--- a/src/pdaaal/AbstractionPAutomaton.h
+++ b/src/pdaaal/AbstractionPAutomaton.h
@@ -32,14 +32,14 @@
 
 namespace pdaaal {
 
-    template <typename T, typename W = void, typename C = std::less<W>, typename A = add<W>>
-    class AbstractionPAutomaton : public PAutomaton<W,C,A> {
+    template <typename T, typename W = void>
+    class AbstractionPAutomaton : public PAutomaton<W> {
     private:
         using nfastate_t = typename NFA<T>::state_t;
     public:
         // TODO: This one is mostly copy-paste from PAutomaton. Clean up later...
-        AbstractionPAutomaton(const AbstractionPDA<T,W,C>& pda, const NFA<T>& nfa, const std::vector<size_t>& states)
-        : PAutomaton<W,C,A>(pda, states, nfa.empty_accept()) {
+        AbstractionPAutomaton(const AbstractionPDA<T,W>& pda, const NFA<T>& nfa, const std::vector<size_t>& states)
+        : PAutomaton<W>(pda, states, nfa.empty_accept()) {
             std::unordered_map<const nfastate_t*, size_t> nfastate_to_id;
             std::vector<std::pair<const nfastate_t*,size_t>> waiting;
             auto get_nfastate_id = [this, &waiting, &nfastate_to_id](const nfastate_t* n) -> size_t {

--- a/src/pdaaal/AbstractionPDA.h
+++ b/src/pdaaal/AbstractionPDA.h
@@ -32,8 +32,8 @@
 
 namespace pdaaal {
 
-    template <typename label_t, typename W, typename C, fut::type Container = fut::type::vector>
-    class AbstractionPDA : public PDA<W, C, Container> {
+    template <typename label_t, typename W, fut::type Container = fut::type::vector>
+    class AbstractionPDA : public PDA<W, Container> {
     public:
 
         template <typename Fn>
@@ -41,8 +41,8 @@ namespace pdaaal {
         : _label_abstraction(AbstractionMapping(std::forward<Fn>(label_abstraction_fn), all_labels.begin(), all_labels.end())) { }
 
         template<fut::type OtherContainer>
-        explicit AbstractionPDA(AbstractionPDA<label_t,W,C,OtherContainer>&& other_pda)
-        : PDA<W,C,Container>(std::move(other_pda)), _label_abstraction(other_pda.move_label_map()) { }
+        explicit AbstractionPDA(AbstractionPDA<label_t,W,OtherContainer>&& other_pda)
+        : PDA<W,Container>(std::move(other_pda)), _label_abstraction(other_pda.move_label_map()) { }
 
         explicit AbstractionPDA(RefinementMapping<label_t>&& mapping)
         : _label_abstraction(std::move(mapping)) { };

--- a/src/pdaaal/CegarPdaFactory.h
+++ b/src/pdaaal/CegarPdaFactory.h
@@ -38,14 +38,14 @@
 namespace pdaaal {
 
     // NOTE: CEGAR construction with weights is not yet implemented.
-    template <typename label_t, typename W = void, typename C = std::less<W>, typename A = add<W>>
-    class CegarPdaFactory : public PDAFactory<label_t, AbstractionPDA<label_t,W,C,fut::type::hash>, AbstractionPDA<label_t,W,C,fut::type::vector>,
-                                       user_rule_t<W,C>, AbstractionSolverInstance<label_t,W,C,A>> {
+    template <typename label_t, typename W = weight<void>>
+    class CegarPdaFactory : public PDAFactory<label_t, AbstractionPDA<label_t,W,fut::type::hash>, AbstractionPDA<label_t,W,fut::type::vector>,
+                                       user_rule_t<W>, AbstractionSolverInstance<label_t,W>> {
     private:
-        using parent_t = PDAFactory<label_t,AbstractionPDA<label_t,W,C,fut::type::hash>, // We optimize for set insertion while building,
-                                    AbstractionPDA<label_t,W,C,fut::type::vector>,       // and then optimize for iteration when analyzing.
-                                    user_rule_t<W,C>, // FIXME: This does not yet work for weighted rules.
-                                    AbstractionSolverInstance<label_t,W,C,A>>;
+        using parent_t = PDAFactory<label_t,AbstractionPDA<label_t,W,fut::type::hash>, // We optimize for set insertion while building,
+                                    AbstractionPDA<label_t,W,fut::type::vector>,       // and then optimize for iteration when analyzing.
+                                    user_rule_t<W>, // FIXME: This does not yet work for weighted rules.
+                                    AbstractionSolverInstance<label_t,W>>;
         using builder_pda_t = typename parent_t::builder_pda_t;
     protected:
         using solver_instance_t = typename parent_t::solver_instance_t;
@@ -104,17 +104,17 @@ namespace pdaaal {
         }
     };
 
-    template <typename label_t, typename state_t, typename configuration_range_t, typename concrete_trace_t, typename W = void, typename C = std::less<W>, typename A = add<W>>
+    template <typename label_t, typename state_t, typename configuration_range_t, typename concrete_trace_t, typename W = weight<void>>
     class CegarPdaReconstruction {
     private:
         using configuration_t = typename std::remove_cv_t<std::remove_reference_t<configuration_range_t>>::value_type;
 
-        using pda_t = AbstractionPDA<label_t,W,C,fut::type::vector>;
+        using pda_t = AbstractionPDA<label_t,W,fut::type::vector>;
         using nfa_state_t = typename NFA<label_t>::state_t;
-        using automaton_t = AbstractionPAutomaton<label_t,W,C,A>;
+        using automaton_t = AbstractionPAutomaton<label_t,W>;
     public:
-        using abstract_rule_t = user_rule_t<W,C>; // FIXME: This does not yet work for weighted rules.
-        using solver_instance_t = AbstractionSolverInstance<label_t,W,C,A>;
+        using abstract_rule_t = user_rule_t<W>; // FIXME: This does not yet work for weighted rules.
+        using solver_instance_t = AbstractionSolverInstance<label_t,W>;
         using header_t = Header<label_t>;
         using state_refinement_t = Refinement<state_t>;
         using label_refinement_t = Refinement<label_t>;
@@ -136,7 +136,7 @@ namespace pdaaal {
                 assert(false); // Not yet supported.
             } else {
                 size_t init_state;
-                std::vector<user_rule_t<W,C>> trace;
+                std::vector<user_rule_t<W>> trace;
                 std::vector<size_t> initial_path, final_path;
                 std::tie(init_state, trace, _initial_abstract_stack, _final_abstract_stack, initial_path, final_path) = Solver::get_rule_trace_and_paths<Trace_Type::Any, use_dual>(_instance);
                 assert(init_state != std::numeric_limits<size_t>::max()); // Assume that a trace exists (otherwise don't call this function!)

--- a/src/pdaaal/PDAFactory.h
+++ b/src/pdaaal/PDAFactory.h
@@ -75,22 +75,22 @@ namespace pdaaal {
         builder_pda_t _temp_pda;
     };
 
-    template<typename T, typename W = void, typename C = std::less<W>, typename A = add<W>>
-    class TypedPDAFactory : public PDAFactory<T, TypedPDA<T,W,C,fut::type::hash>, TypedPDA<T,W,C,fut::type::vector>,
-                                       typename TypedPDA<T,W,C,fut::type::hash>::rule_t, SolverInstance<T,W,C,A>> {
+    template<typename T, typename W = weight<void>>
+    class TypedPDAFactory : public PDAFactory<T, TypedPDA<T,W,fut::type::hash>, TypedPDA<T,W,fut::type::vector>,
+                                       typename TypedPDA<T,W,fut::type::hash>::rule_t, SolverInstance<T,W>> {
     private:
-        using parent_t = PDAFactory<T, TypedPDA<T,W,C,fut::type::hash>, TypedPDA<T,W,C,fut::type::vector>,
-                                    typename TypedPDA<T,W,C,fut::type::hash>::rule_t, SolverInstance<T,W,C,A>>;
+        using parent_t = PDAFactory<T, TypedPDA<T,W,fut::type::hash>, TypedPDA<T,W,fut::type::vector>,
+                                    typename TypedPDA<T,W,fut::type::hash>::rule_t, SolverInstance<T,W>>;
     public:
         using rule_t = typename parent_t::rule_t;
         explicit TypedPDAFactory(const std::unordered_set<T>& all_labels) : parent_t(all_labels) { };
     };
 
     // This is the 'old' PDAFactory.
-    template<typename T, typename W = void, typename C = std::less<W>, typename A = add<W>>
-    class DFS_PDAFactory : public TypedPDAFactory<T,W,C,A> {
+    template<typename T, typename W = weight<void>>
+    class DFS_PDAFactory : public TypedPDAFactory<T,W> {
     private:
-        using parent_t = TypedPDAFactory<T,W,C,A>;
+        using parent_t = TypedPDAFactory<T,W>;
     public:
         using rule_t = typename parent_t::rule_t;
         DFS_PDAFactory(const std::unordered_set<T>& all_labels, T wildcard_label)

--- a/src/pdaaal/Reducer.h
+++ b/src/pdaaal/Reducer.h
@@ -62,8 +62,8 @@ namespace pdaaal {
         };
 
     public:
-        template <typename W, typename C>
-        static std::pair<size_t, size_t> reduce(PDA<W,C> &pda, int aggresivity, size_t initial_id, size_t terminal_id) {
+        template <typename W>
+        static std::pair<size_t, size_t> reduce(PDA<W> &pda, int aggresivity, size_t initial_id, size_t terminal_id) {
             size_t cnt = Reducer::size(pda, initial_id, terminal_id);
             if (aggresivity == 0)
                 return std::make_pair(cnt, cnt);
@@ -167,8 +167,8 @@ namespace pdaaal {
             return std::make_pair(cnt, after_cnt);
         }
 
-        template <typename W, typename C>
-        static void forwards_prune(PDA<W,C> &pda, size_t initial_id) {
+        template <typename W>
+        static void forwards_prune(PDA<W> &pda, size_t initial_id) {
             std::queue<size_t> waiting;
             std::vector<bool> seen(pda.states().size());
             waiting.push(initial_id);
@@ -190,8 +190,8 @@ namespace pdaaal {
             }
         }
 
-        template <typename W, typename C>
-        static void backwards_prune(PDA<W,C> &pda, size_t terminal) {
+        template <typename W>
+        static void backwards_prune(PDA<W> &pda, size_t terminal) {
             std::queue<size_t> waiting;
             std::vector<bool> seen(pda.states().size());
             waiting.push(terminal);
@@ -214,8 +214,8 @@ namespace pdaaal {
             }
         }
 
-        template <typename W, typename C>
-        static void target_tos_prune(PDA<W,C> &pda, size_t terminal_id) {
+        template <typename W>
+        static void target_tos_prune(PDA<W> &pda, size_t terminal_id) {
             std::queue<size_t> waiting;
             std::vector<bool> in_waiting(pda.states().size());
             for (size_t t = 0; t < pda.states().size(); ++t) {
@@ -279,8 +279,8 @@ namespace pdaaal {
         }
 
     private:
-        template <typename W, typename C>
-        static size_t size(const PDA<W,C> &pda, size_t initial_id, size_t terminal_id)
+        template <typename W>
+        static size_t size(const PDA<W> &pda, size_t initial_id, size_t terminal_id)
         {
             size_t cnt = 1;
             // lets start by the initial transitions

--- a/src/pdaaal/TypedPDA.h
+++ b/src/pdaaal/TypedPDA.h
@@ -40,10 +40,10 @@
 
 namespace pdaaal {
 
-    template<typename T, typename W = void, typename C = std::less<W>, fut::type Container = fut::type::vector>
-    class TypedPDA : public PDA<W, C, Container> {
+    template<typename T, typename W = weight<void>, fut::type Container = fut::type::vector>
+    class TypedPDA : public PDA<W, Container> {
     protected:
-        using impl_rule_t = typename PDA<W, C, Container>::rule_t; // This rule type is used internally.
+        using impl_rule_t = typename PDA<W, Container>::rule_t; // This rule type is used internally.
 
     private:
         template <typename WT, typename = void> struct rule_t_;
@@ -62,7 +62,7 @@ namespace pdaaal {
             size_t _to = std::numeric_limits<size_t>::max();
             op_t _op = POP;
             T _op_label;
-            WT _weight;
+            typename WT::type _weight;
         };
     public:
         using rule_t = rule_t_<W>; // This rule type can be used by users of the library.
@@ -75,8 +75,8 @@ namespace pdaaal {
 
     public:
         template<fut::type OtherContainer>
-        explicit TypedPDA(TypedPDA<T,W,C,OtherContainer>&& other_pda)
-        : PDA<W,C,Container>(std::move(other_pda)), _label_map(other_pda.move_label_map()) {}
+        explicit TypedPDA(TypedPDA<T,W,OtherContainer>&& other_pda)
+        : PDA<W,Container>(std::move(other_pda)), _label_map(other_pda.move_label_map()) {}
 
         explicit TypedPDA(const std::unordered_set<T>& all_labels) {
             std::set<T> sorted(all_labels.begin(), all_labels.end());
@@ -190,7 +190,7 @@ namespace pdaaal {
 
         template<typename WT, typename = std::enable_if_t<is_weighted<WT>>>
         void add_rules_(size_t from, size_t to, op_t op, bool negated, const std::vector<T> &labels, bool negated_pre,
-                        const std::vector<T> &pre, WT weight = zero<WT>()()) {
+                        const std::vector<T> &pre, typename WT::type weight = WT::zero()) {
             add_rules_impl(from, {to, op, weight}, negated, labels, negated_pre, pre);
         }
 
@@ -202,7 +202,7 @@ namespace pdaaal {
         }
 
         template<typename WT, typename = std::enable_if_t<is_weighted<WT>>>
-        void add_rule_(size_t from, size_t to, op_t op, T label, bool negated, const std::vector<T> &pre, WT weight = zero<WT>()()) {
+        void add_rule_(size_t from, size_t to, op_t op, T label, bool negated, const std::vector<T> &pre, typename WT::type weight = WT::zero()) {
             auto lid = find_labelid(op, label);
             auto tpre = encode_pre(pre);
             this->add_untyped_rule(from, to, op, lid, weight, negated, tpre);
@@ -215,7 +215,7 @@ namespace pdaaal {
         }
 
         template<typename WT, typename = std::enable_if_t<is_weighted<WT>>>
-        void add_rule_(size_t from, size_t to, op_t op, T label, T pre, WT weight = zero<WT>()()) {
+        void add_rule_(size_t from, size_t to, op_t op, T label, T pre, typename WT::type weight = WT::zero()) {
             std::vector<T> _pre{pre};
             add_rule(from, to, op, label, false, _pre, weight);
         }

--- a/src/pdaaal/Weight.h
+++ b/src/pdaaal/Weight.h
@@ -40,28 +40,30 @@
 namespace pdaaal {
 
     template<typename W, typename = void> struct weight;
+    template <> struct weight<void> { using type = void; };
     template<typename W>
     struct weight<W, std::enable_if_t<std::is_arithmetic_v<W> && std::numeric_limits<W>::is_specialized>> {
         using type = W;
-        static constexpr type zero = (type)0;
-        static constexpr type max = std::numeric_limits<type>::max();
+        static constexpr type max_val = std::numeric_limits<type>::max();
+        static constexpr auto zero = []() -> type { return (type)0; };
+        static constexpr auto max = []() -> type { return std::numeric_limits<type>::max(); };
         static constexpr bool less(type lhs, type rhs) {
             return lhs < rhs;
         }
         static constexpr type add(type lhs, type rhs) {
-            if (lhs == max || rhs == max) return max;
+            if (lhs == max_val || rhs == max_val) return max_val;
             return lhs + rhs;
         };
         static constexpr type multiply(type lhs, type rhs) {
-            if (lhs == max || rhs == max) return max;
+            if (lhs == max_val || rhs == max_val) return max_val;
             return lhs * rhs;
         };
     };
     template<typename Inner, std::size_t N>
     struct weight<std::array<Inner, N>, std::enable_if_t<std::is_arithmetic_v<Inner> && std::numeric_limits<Inner>::is_specialized>> {
         using type = std::array<Inner, N>;
-        static constexpr type zero = [](){std::array<Inner, N> arr{}; arr.fill(weight<Inner>::zero); return arr;}();
-        static constexpr type max = [](){std::array<Inner, N> arr{}; arr.fill(weight<Inner>::max); return arr;}();
+        static constexpr auto zero = []() -> type {std::array<Inner, N> arr{}; arr.fill(weight<Inner>::zero()); return arr;};
+        static constexpr auto max = []() -> type {std::array<Inner, N> arr{}; arr.fill(weight<Inner>::max()); return arr;};
         static constexpr bool less(const type& lhs, const type& rhs) {
             return lhs < rhs;
         }
@@ -76,8 +78,8 @@ namespace pdaaal {
     template<typename Inner>
     struct weight<std::vector<Inner>, std::enable_if_t<std::is_arithmetic_v<Inner> && std::numeric_limits<Inner>::is_specialized>> {
         using type = std::vector<Inner>;
-        static constexpr type zero = type{};
-        static constexpr type max = type{weight<Inner>::max};
+        static constexpr auto zero = []() -> type { return type{}; };
+        static constexpr auto max = []() -> type { return type{weight<Inner>::max()}; }; // TODO: When C++20 arrives, use a constexpr vector instead
         static constexpr bool less(const type& lhs, const type& rhs) {
             return lhs < rhs;
         }
@@ -89,124 +91,37 @@ namespace pdaaal {
             return result;
         };
     };
+
+    template <typename T, typename = void> struct has_type : std::false_type {};
+    template <typename T> struct has_type<T, std::void_t<decltype(std::declval<typename T::type>())>> : std::true_type {};
+    template <typename T> inline constexpr auto has_type_v = has_type<T>::value;
+
     template <typename T, typename = void> struct has_zero : std::false_type {};
-    template <typename T> struct has_zero<T, std::void_t<decltype(T::zero)>> : std::true_type {};
+    template <typename T> struct has_zero<T, std::void_t<decltype(T::zero())>> : std::true_type {};
     template <typename T> inline constexpr auto has_zero_v = has_zero<T>::value;
 
     template <typename T, typename = void> struct has_max : std::false_type {};
-    template <typename T> struct has_max<T, std::void_t<decltype(T::max)>> : std::true_type {};
+    template <typename T> struct has_max<T, std::void_t<decltype(T::max())>> : std::true_type {};
     template <typename T> inline constexpr auto has_max_v = has_max<T>::value;
 
     template <typename T, typename = void> struct has_less : std::false_type {};
-    template <typename T> struct has_less<T, std::void_t<decltype(T::less(std::declval<T>(), std::declval<T>()))>> : std::true_type {};
+    template <typename T> struct has_less<T, std::void_t<decltype(T::less(std::declval<typename T::type>(), std::declval<typename T::type>()))>> : std::true_type {};
     template <typename T> inline constexpr auto has_less_v = has_less<T>::value;
 
     template <typename T, typename = void> struct has_add : std::false_type {};
-    template <typename T> struct has_add<T, std::void_t<decltype(T::add(std::declval<T>(), std::declval<T>()))>> : std::true_type {};
+    template <typename T> struct has_add<T, std::void_t<decltype(T::add(std::declval<typename T::type>(), std::declval<typename T::type>()))>> : std::true_type {};
     template <typename T> inline constexpr auto has_add_v = has_add<T>::value;
 
     template <typename T, typename = void> struct has_boost_hash : std::false_type {};
-    template <typename T> struct has_boost_hash<T, std::void_t<decltype(std::declval<boost::hash<T>>()(std::declval<T>()))>> : std::true_type {};
+    template <typename T> struct has_boost_hash<T, std::void_t<decltype(std::declval<boost::hash<typename T::type>>())>> : std::true_type {};
     template <typename T> inline constexpr auto has_boost_hash_v = has_boost_hash<T>::value;
 
-    template<typename W> inline constexpr auto is_weighted = !std::is_void_v<W> && has_zero_v<W> && has_max_v<W> && has_less_v<W> && has_add_v<W> && has_boost_hash_v<W>;
+    template<typename W> inline constexpr auto is_weighted =
+            !std::is_void_v<W> && has_type_v<W> && !std::is_void_v<typename W::type> &&
+            has_zero_v<W> && has_max_v<W> && has_less_v<W> && has_add_v<W> && has_boost_hash_v<W>;
 
-//    template<typename W, typename = void> struct zero;
-//    template<typename W, typename = void> struct max;
-//    template<typename W, typename = void> struct add;
-//
-//    template<typename W>
-//    struct zero<W, std::enable_if_t<std::is_arithmetic_v<W>>> {
-//        constexpr W operator()() const {
-//            return (W) 0;
-//        };
-//    };
-//
-//    template<typename W>
-//    struct max<W, std::enable_if_t<std::numeric_limits<W>::is_specialized>> {
-//        constexpr W operator()() const {
-//            return std::numeric_limits<W>::max();
-//        };
-//    };
-//
-//    template<typename W>
-//    struct add<W, std::enable_if_t<std::is_arithmetic_v<W>>> {
-//        constexpr W operator()(W lhs, W rhs) const {
-//            return lhs + rhs;
-//        };
-//    };
-//
-//    template<typename Inner, std::size_t N>
-//    struct zero<std::array<Inner, N>, std::enable_if_t<has_zero_v<Inner>>> {
-//        constexpr std::array<Inner, N> operator()() const {
-//            std::array<Inner, N> arr{};
-//            arr.fill(zero<Inner>()());
-//            return arr;
-//        };
-//    };
-//
-//    template<typename Inner, std::size_t N>
-//    struct max<std::array<Inner, N>, std::enable_if_t<has_max_v<Inner>>> {
-//        constexpr std::array<Inner, N> operator()() const {
-//            std::array<Inner, N> arr{};
-//            arr.fill(max<Inner>()());
-//            return arr;
-//        };
-//    };
-//
-//    template<typename Inner, std::size_t N>
-//    struct add<std::array<Inner, N>, std::enable_if_t<has_add_v<Inner>>> {
-//        constexpr std::array<Inner, N> operator()(std::array<Inner, N> lhs, std::array<Inner, N> rhs) const {
-//            std::array<Inner, N> res{};
-//            for (size_t i = 0; i < N; ++i) {
-//                res[i] = lhs[i] + rhs[i];
-//            }
-//            return res;
-//        };
-//    };
-//
-//
-//    template<typename Inner>
-//    struct zero<std::vector<Inner>, std::enable_if_t<has_zero_v<Inner>>> {
-//        constexpr std::vector<Inner> operator()() const {
-//            std::vector<Inner> vec;
-//            return vec;
-//        };
-//    };
-//
-//    template<typename Inner>
-//    struct max<std::vector<Inner>, std::enable_if_t<has_max_v<Inner>>> {
-//        constexpr std::vector<Inner> operator()() const {
-//            std::vector<Inner> vec{max<Inner>()()};
-//            return vec;
-//        };
-//    };
-//
-//    template<typename Inner>
-//    struct add<std::vector<Inner>, std::enable_if_t<has_add_v<Inner>>> {
-//        constexpr std::vector<Inner> operator()(const std::vector<Inner>& lhs, const std::vector<Inner>& rhs) const {
-//            auto l_size = lhs.size();
-//            auto r_size = rhs.size();
-//            auto min = l_size < r_size ? l_size : r_size;
-//            auto max = l_size < r_size ? r_size : l_size;
-//            auto &large = max == l_size ? lhs : rhs;
-//            std::vector<Inner> res(max);
-//            add<Inner> add_i;
-//            size_t i = 0;
-//            for (; i < min; ++i) {
-//                res[i] = add_i(lhs[i], rhs[i]);
-//            }
-//            for (; i < max; ++i) {
-//                res[i] = large[i];
-//            }
-//            return res;
-//        };
-//    };
-
-
-    template<typename W, typename = void> struct mult;
     template <typename T, typename = void> struct has_mult : std::false_type {};
-    template <typename T> struct has_mult<T, std::void_t<decltype(T::multiply(std::declval<T>(), std::declval<T>()))>> : std::true_type {};
+    template <typename T> struct has_mult<T, std::void_t<decltype(T::multiply(std::declval<typename T::type>(), std::declval<typename T::type>()))>> : std::true_type {};
     template <typename T> constexpr auto has_mult_v = has_mult<T>::value;
 
     template <typename W, typename... Args>
@@ -215,7 +130,7 @@ namespace pdaaal {
         const std::vector<std::pair<W, linear_weight_function<W, Args...>>> _functions;
         const std::optional<std::function<W(Args...)>> _function;
     public:
-        static_assert(is_weighted<W>);
+        static_assert(is_weighted<weight<W>>);
         using result_type = W;
 
         // A single function
@@ -223,16 +138,16 @@ namespace pdaaal {
 
         // Linear combination of functions
         explicit linear_weight_function(std::vector<std::pair<W, linear_weight_function<W, Args...>>> functions) : _functions(functions) {
-            static_assert(has_mult_v<W>, "For a linear combination, the weight type W needs to implement W::multiply.");
+            static_assert(has_mult_v<weight<W>>, "For a linear combination, the weight type W needs to implement W::multiply.");
         }
 
         constexpr result_type operator()(Args... args) const {
             if (_function) {
                 return _function.value()(args...);
             }
-            return std::accumulate(_functions.begin(), _functions.end(), W::zero,
+            return std::accumulate(_functions.begin(), _functions.end(), weight<W>::zero(),
                     [&args...](const W& lhs, const std::pair<W, linear_weight_function<W, Args...>>& rhs) -> W {
-                return W::add(lhs, mult<W>()(rhs.first, rhs.second(args...)));
+                return weight<W>::add(lhs, weight<W>::multiply(rhs.first, rhs.second(args...)));
             });
         }
     };
@@ -244,7 +159,7 @@ namespace pdaaal {
     private:
         const std::vector<linear_weight_function<W, Args...>> _functions;
     public:
-        static_assert(is_weighted<W>);
+        static_assert(is_weighted<weight<W>>);
         using result_type = std::vector<W>;
 
         explicit ordered_weight_function(std::vector<linear_weight_function<W, Args...>> functions) : _functions(functions) {}

--- a/test/PAutomaton_test.cpp
+++ b/test/PAutomaton_test.cpp
@@ -37,7 +37,7 @@ using namespace pdaaal;
 BOOST_AUTO_TEST_CASE(Dijkstra_Test_1)
 {
     std::unordered_set<char> labels{'A'};
-    TypedPDA<char, int> pda(labels);
+    TypedPDA<char, weight<int>> pda(labels);
     pda.add_rule(0, 0, POP, '*', 'A', 0);
 
     PAutomaton automaton(pda, std::vector<size_t>());
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(WeightedPreStar)
     // This is pretty much the rules from the example in Figure 3.1 (Schwoon-php02)
     // However r_2 requires a swap and a push, which is done through auxiliary state 3.
     std::unordered_set<char> labels{'A', 'B', 'C'};
-    TypedPDA<char, std::vector<int>> pda(labels);
+    TypedPDA<char, weight<std::vector<int>>> pda(labels);
     std::vector<int> w{1};
     pda.add_rule(0, 1, PUSH, 'B', 'A', w);
     pda.add_rule(0, 0, POP , '*', 'B', w);
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(WeightedPostStar)
     // This is pretty much the rules from the example in Figure 3.1 (Schwoon-php02)
     // However r_2 requires a swap and a push, which is done through auxiliary state 3.
     std::unordered_set<char> labels{'A', 'B', 'C'};
-    TypedPDA<char, std::array<double, 3>> pda(labels);
+    TypedPDA<char, weight<std::array<double, 3>>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
     pda.add_rule(0, 1, PUSH, 'B', 'A', w);
     pda.add_rule(0, 0, POP , '*', 'B', w);
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(WeightedPostStar)
 BOOST_AUTO_TEST_CASE(WeightedPostStar2)
 {
     std::unordered_set<char> labels{'A', 'B'};
-    TypedPDA<char, int> pda(labels);
+    TypedPDA<char, weight<int>> pda(labels);
 
     pda.add_rule(1, 2, POP, '*', 'A', 1);
     pda.add_rule(1, 3, PUSH , 'B', 'A', 3);
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(WeightedPostStar2)
 BOOST_AUTO_TEST_CASE(WeightedPostStar3)
 {
     std::unordered_set<char> labels{'A'};
-    TypedPDA<char, int> pda(labels);
+    TypedPDA<char, weight<int>> pda(labels);
     std::vector<char> pre{'A'};
 
     pda.add_rule(1, 2, PUSH, 'A', 'A', 16);
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(WeightedPostStar3)
 BOOST_AUTO_TEST_CASE(WeightedPostStar4)
 {
     std::unordered_set<char> labels{'A'};
-    TypedPDA<char, int> pda(labels);
+    TypedPDA<char, weight<int>> pda(labels);
 
     pda.add_rule(0, 3, PUSH, 'A', 'A', 4);
     pda.add_rule(0, 1, PUSH , 'A', 'A', 1);
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(WeightedPostStar4)
 BOOST_AUTO_TEST_CASE(WeightedPostStarResult)
 {
     std::unordered_set<char> labels{'A'};
-    TypedPDA<char, int> pda(labels);
+    TypedPDA<char, weight<int>> pda(labels);
 
     pda.add_rule(0, 3, PUSH, 'A', 'A', 4);
     pda.add_rule(0, 1, PUSH , 'A', 'A', 1);
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE(WeightedPostStarResult)
 BOOST_AUTO_TEST_CASE(WeightedPostStar4EarlyTermination)
 {
     std::unordered_set<char> labels{'A'};
-    TypedPDA<char, int> pda(labels);
+    TypedPDA<char, weight<int>> pda(labels);
 
     pda.add_rule(0, 3, PUSH, 'A', 'A', 4);
     pda.add_rule(0, 1, PUSH , 'A', 'A', 1);
@@ -302,13 +302,13 @@ BOOST_AUTO_TEST_CASE(WeightedPostStar4EarlyTermination)
     BOOST_CHECK_EQUAL(distance4A, 30);          //Example Derived on whiteboard
 }
 
-TypedPDA<int,int> create_syntactic_network_broad(int network_size = 2) {
+TypedPDA<int,weight<int>> create_syntactic_network_broad(int network_size = 2) {
     std::unordered_set<int> labels{0,1,2};
     int start_state = 0;
     int states = 4;
     int end_state = 4;
 
-    TypedPDA<int, int> pda(labels);
+    TypedPDA<int, weight<int>> pda(labels);
 
     for (int j = 0; j < network_size; j++) {
         pda.add_rule(start_state, 1 + start_state, PUSH, 0, 0, 0);
@@ -337,9 +337,9 @@ TypedPDA<int,int> create_syntactic_network_broad(int network_size = 2) {
     return pda;
 }
 
-TypedPDA<int,int> create_syntactic_network_deep(int network_size = 2){
+TypedPDA<int,weight<int>> create_syntactic_network_deep(int network_size = 2){
     std::unordered_set<int> labels{0,1,2};
-    TypedPDA<int, int> pda(labels);
+    TypedPDA<int, weight<int>> pda(labels);
     int start_state = 0;
     int new_start_state = 4;
     int end_state = 2;
@@ -374,7 +374,7 @@ TypedPDA<int,int> create_syntactic_network_deep(int network_size = 2){
 
 BOOST_AUTO_TEST_CASE(WeightedPostStarSyntacticModel)
 {
-    TypedPDA<int,int> pda = create_syntactic_network_broad(1);
+    TypedPDA<int,weight<int>> pda = create_syntactic_network_broad(1);
     std::vector<int> init_stack;
     init_stack.push_back(0);
     PAutomaton automaton(pda, 0, pda.encode_pre(init_stack));
@@ -399,7 +399,7 @@ BOOST_AUTO_TEST_CASE(WeightedPostStarVSPostUnorderedPerformance)
         labels.insert(i);
     }
 
-    TypedPDA<int, int> pda(labels);
+    TypedPDA<int, weight<int>> pda(labels);
 
     for(int i = 0; i < alphabet_size; i++){
         pda.add_rule(0, 1, SWAP, i, 0, 1);
@@ -431,7 +431,7 @@ BOOST_AUTO_TEST_CASE(WeightedPostStarVSPostUnorderedPerformance)
 
 BOOST_AUTO_TEST_CASE(WeightedShortestPerformance)
 {
-    TypedPDA<int, int> pda = create_syntactic_network_deep(200);
+    TypedPDA<int, weight<int>> pda = create_syntactic_network_deep(200);
 
     std::vector<int> init_stack;
     init_stack.push_back(0);

--- a/test/PDA_test.cpp
+++ b/test/PDA_test.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(VoidWeight)
 BOOST_AUTO_TEST_CASE(IntWeight)
 {
     std::unordered_set<char> labels{'a', 'b'};
-    TypedPDA<char, int> pda(labels); // Check if it compiles
+    TypedPDA<char, weight<int>> pda(labels); // Check if it compiles
     BOOST_CHECK_EQUAL(true, true);
 }
 
@@ -81,10 +81,10 @@ BOOST_AUTO_TEST_CASE(LabelsMerge)
 
 BOOST_AUTO_TEST_CASE(PDA_Container_Type) {
     std::unordered_set<char> labels{'A', 'B'};
-    TypedPDA<char,int,std::less<int>,fut::type::hash> pda(labels);
+    TypedPDA<char,weight<int>,fut::type::hash> pda(labels);
     pda.add_rule(0, 1, PUSH, 'B', 'A');
 
-    TypedPDA<char,int> pda2(std::move(pda));
+    TypedPDA<char,weight<int>> pda2(std::move(pda));
 
     pda2.add_rule(1, 3, SWAP, 'A', 'B');
 

--- a/test/ParsingPDAFactory_test.cpp
+++ b/test/ParsingPDAFactory_test.cpp
@@ -109,7 +109,7 @@ A,B
 1 B -> 2 +B | 1
 2 B -> 0 - | 1
 )");
-    auto factory = ParsingPDAFactory<unsigned int>::create(i_stream);
+    auto factory = ParsingPDAFactory<weight<unsigned int>>::create(i_stream);
 
     // initial stack: [A,B]
     NFA<std::string> initial(std::unordered_set<std::string>{"A"});

--- a/test/Reducer_test.cpp
+++ b/test/Reducer_test.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(ReducerTest1) {
     // This is pretty much the rules from the example in Figure 3.1 (Schwoon-php02)
     // However r_2 requires a swap and a push, which is done through auxiliary state 3.
     std::unordered_set<char> labels{'A', 'B', 'C'};
-    TypedPDA<char, std::array<double, 3>> pda(labels);
+    TypedPDA<char, weight<std::array<double, 3>>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
     pda.add_rule(0, 1, PUSH, 'B', 'A', w);
     pda.add_rule(0, 0, POP , '*', 'B', w);

--- a/test/Solver_test.cpp
+++ b/test/Solver_test.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(SolverTest1)
     // This is pretty much the rules from the example in Figure 3.1 (Schwoon-php02)
     // However r_2 requires a swap and a push, which is done through auxiliary state 3.
     std::unordered_set<char> labels{'A', 'B', 'C'};
-    TypedPDA<char, std::array<double, 3>> pda(labels);
+    TypedPDA<char, weight<std::array<double, 3>>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
     pda.add_rule(0, 1, PUSH, 'B', 'A', w);
     pda.add_rule(0, 0, POP , '*', 'B', w);
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(SolverTest2)
     // This is pretty much the rules from the example in Figure 3.1 (Schwoon-php02)
     // However r_2 requires a swap and a push, which is done through auxiliary state 3.
     std::unordered_set<uint32_t> labels{2,3,4};
-    TypedPDA<uint32_t, std::array<double, 3>> pda(labels);
+    TypedPDA<uint32_t, weight<std::array<double, 3>>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
     pda.add_rule(0, 1, PUSH, 3, 2, w);
     pda.add_rule(0, 0, POP , '*', 3, w);
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(SolverTest3)
     // This is pretty much the rules from the example in Figure 3.1 (Schwoon-php02)
     // However r_2 requires a swap and a push, which is done through auxiliary state 3.
     std::unordered_set<char> labels{'A', 'B', 'C'};
-    TypedPDA<char, std::array<double, 3>> pda(labels);
+    TypedPDA<char, weight<std::array<double, 3>>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
     pda.add_rule(0, 1, PUSH, 'B', 'A', w);
     pda.add_rule(0, 0, POP , '*', 'B', w);
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(EarlyTerminationPostStar)
     // This is pretty much the rules from the example in Figure 3.1 (Schwoon-php02)
     // However r_2 requires a swap and a push, which is done through auxiliary state 3.
     std::unordered_set<char> labels{'A', 'B', 'C'};
-    TypedPDA<char, std::array<double, 3>> pda(labels);
+    TypedPDA<char, weight<std::array<double, 3>>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
     pda.add_rule(0, 1, PUSH, 'B', 'A', w);
     pda.add_rule(0, 0, POP , '*', 'B', w);
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(EarlyTerminationPreStar)
     // This is pretty much the rules from the example in Figure 3.1 (Schwoon-php02)
     // However r_2 requires a swap and a push, which is done through auxiliary state 3.
     std::unordered_set<char> labels{'A', 'B', 'C'};
-    TypedPDA<char, std::array<double, 3>> pda(labels);
+    TypedPDA<char, weight<std::array<double, 3>>> pda(labels);
     std::array<double, 3> w{0.5, 1.2, 0.3};
     pda.add_rule(0, 1, PUSH, 'B', 'A', w);
     pda.add_rule(0, 0, POP , '*', 'B', w);

--- a/test/Weight_test.cpp
+++ b/test/Weight_test.cpp
@@ -37,24 +37,22 @@ BOOST_AUTO_TEST_CASE(VectorWeight) {
     std::vector<int> c{3,1,9};
     std::vector<int> d{3,0,9};
     std::vector<int> e;
-
-    const add<std::vector<int>> add;
-    auto result_1 = add(a,b);
+    using W = weight<std::vector<int>>;
+    auto result_1 = W::add(a,b);
     std::vector<int> expected_1{4,8,42};
     BOOST_CHECK_EQUAL_COLLECTIONS(result_1.begin(), result_1.end(), expected_1.begin(), expected_1.end());
 
-    auto result_2 = add(e,a);
+    auto result_2 = W::add(e,a);
     auto expected_2 = a;
     BOOST_CHECK_EQUAL_COLLECTIONS(result_2.begin(), result_2.end(), expected_2.begin(), expected_2.end());
 
-    const std::less<> less;
-    BOOST_CHECK_EQUAL(less(a,b), true);
-    BOOST_CHECK_EQUAL(less(b,a), false);
-    BOOST_CHECK_EQUAL(less(b,c), true);
-    BOOST_CHECK_EQUAL(less(c,d), false);
-    BOOST_CHECK_EQUAL(less(d,a), false);
-    BOOST_CHECK_EQUAL(less(e,a), true);
-    BOOST_CHECK_EQUAL(less(a,a), false);
+    BOOST_CHECK_EQUAL(W::less(a,b), true);
+    BOOST_CHECK_EQUAL(W::less(b,a), false);
+    BOOST_CHECK_EQUAL(W::less(b,c), true);
+    BOOST_CHECK_EQUAL(W::less(c,d), false);
+    BOOST_CHECK_EQUAL(W::less(d,a), false);
+    BOOST_CHECK_EQUAL(W::less(e,a), true);
+    BOOST_CHECK_EQUAL(W::less(a,a), false);
 }
 
 


### PR DESCRIPTION
Putting all weight operations into one structure simplifies the code where weights are used.