### PR TITLE
Take epsilon transitions into account in ProductPAutomaton + test

### DIFF
--- a/src/include/pdaaal/AutomatonPath.h
+++ b/src/include/pdaaal/AutomatonPath.h
@@ -76,8 +76,10 @@ namespace pdaaal {
             std::vector<size_t>   path;  path.reserve(_edges.size() + 1);
             std::vector<uint32_t> stack; stack.reserve(_edges.size());
             for (auto it = _edges.crbegin(); it != _edges.crend(); ++it) {
-                path.push_back(it->second);
-                stack.push_back(it->first);
+                if (it->first != std::numeric_limits<uint32_t>::max()) {
+                    path.push_back(it->second);
+                    stack.push_back(it->first);
+                }
             }
             path.push_back(_end);
             return std::make_pair(path, stack);

--- a/src/include/pdaaal/PAutomaton.h
+++ b/src/include/pdaaal/PAutomaton.h
@@ -235,14 +235,14 @@ namespace pdaaal {
                     const std::function<void(std::ostream &, const uint32_t&)>& label_printer = [](auto &s, auto &l){ s << l; },
                     const std::function<void(std::ostream &, const size_t&)>& state_printer = [](auto &s, auto &id){ s << id; }) const {
             out << "digraph NFA {\n";
-            for (auto &s : _states) {
+            for (const auto& s : _states) {
                 out << "\"";
                 state_printer(out, s->_id);
                 out << "\" [shape=";
                 if (s->_accepting)
                     out << "double";
                 out << "circle];\n";
-                for (const auto &[to, labels] : s->_edges) {
+                for (const auto& [to, labels] : s->_edges) {
                     out << "\"";
                     state_printer(out, s->_id);
                     out << "\" -> \"";
@@ -304,7 +304,7 @@ namespace pdaaal {
                     out << "\"];\n";
                 }
             }
-            for (auto &i : _initial) {
+            for (const auto& i : _initial) {
                 out << "\"I";
                 state_printer(out, i->_id);
                 out << "\" -> \"";
@@ -365,10 +365,7 @@ namespace pdaaal {
                     : _weight(weight), _state(state), _stack_index(stack_index), _back_pointer(back_pointer) {};
 
                     bool operator<(const queue_elem& other) const {
-                        if (_state != other._state) {
-                            return _state < other._state;
-                        }
-                        return _stack_index < other._stack_index;
+                        return std::tie(_state, _stack_index) < std::tie(other._state, other._stack_index);
                     }
                     bool operator==(const queue_elem& other) const {
                         return _state == other._state && _stack_index == other._stack_index;
@@ -411,7 +408,7 @@ namespace pdaaal {
                     auto u_pointer = std::make_unique<queue_elem>(*lb);
                     auto pointer = u_pointer.get();
                     pointers.push_back(std::move(u_pointer));
-                    for (const auto &[to,labels] : _states[current._state]->_edges) {
+                    for (const auto& [to,labels] : _states[current._state]->_edges) {
                         auto label = labels.get(stack[current._stack_index]);
                         if (label != nullptr) {
                             if (current._stack_index + 1 < stack.size() || _states[to]->_accepting) {

--- a/src/include/pdaaal/PDA.h
+++ b/src/include/pdaaal/PDA.h
@@ -100,21 +100,14 @@ namespace pdaaal::details {
         op_t _operation = PUSH;
         uint32_t _op_label = 0;
 
-        bool operator<(const rule_t<W> &other) const {
-            if (_to != other._to)
-                return _to < other._to;
-            if (_op_label != other._op_label)
-                return _op_label < other._op_label;
-            return _operation < other._operation;
+        bool operator<(const rule_t<W>& other) const {
+            return std::tie(      _to,       _op_label,       _operation)
+                 < std::tie(other._to, other._op_label, other._operation);
         }
-
-        bool operator==(const rule_t<W> &other) const {
+        bool operator==(const rule_t<W>& other) const {
             return _to == other._to && _op_label == other._op_label && _operation == other._operation;
         }
-
-        bool operator!=(const rule_t<W> &other) const {
-            return !(*this == other);
-        }
+        bool operator!=(const rule_t<W>& other) const { return !(*this == other); }
 
         template <typename H>
         friend H AbslHashValue(H h, const rule_t<W>& rule) {
@@ -129,7 +122,7 @@ namespace pdaaal::details {
         typename W::type _weight = W::zero();
         uint32_t _op_label = 0;
 
-        bool operator<(const rule_t<W> &other) const {
+        bool operator<(const rule_t<W>& other) const {
             if (_to != other._to)
                 return _to < other._to;
             if (_op_label != other._op_label)
@@ -138,15 +131,11 @@ namespace pdaaal::details {
                 return _operation < other._operation;
             return W::less(_weight, other._weight);
         }
-
-        bool operator==(const rule_t<W> &other) const {
+        bool operator==(const rule_t<W>& other) const {
             return _to == other._to && _op_label == other._op_label && _operation == other._operation &&
                    _weight == other._weight;
         }
-
-        bool operator!=(const rule_t<W> &other) const {
-            return !(*this == other);
-        }
+        bool operator!=(const rule_t<W>& other) const { return !(*this == other); }
 
         template <typename H>
         friend H AbslHashValue(H h, const rule_t<W>& rule) {

--- a/src/include/pdaaal/utils/vector_set.h
+++ b/src/include/pdaaal/utils/vector_set.h
@@ -46,9 +46,15 @@ namespace pdaaal::fut {
             explicit elem_t(std::pair<Key,Value>&& arg) : first(std::move(arg.first)), second(std::move(arg.second)) {};
             Key first;
             Value second;
-            bool operator<(const elem_t &other) const { return first < other.first; }
-            bool operator==(const elem_t &other) const { return first == other.first; }
-            bool operator!=(const elem_t &other) const { return !(*this == other); }
+            friend bool operator<( const elem_t& l, const elem_t& r) { return l.first < r.first; }
+            friend bool operator==(const elem_t& l, const elem_t& r) { return l.first == r.first; }
+            friend bool operator!=(const elem_t& l, const elem_t& r) { return !(l == r); }
+            friend bool operator<( const elem_t& l, const Key& r) { return l.first < r; }
+            friend bool operator==(const elem_t& l, const Key& r) { return l.first == r; }
+            friend bool operator!=(const elem_t& l, const Key& r) { return !(l == r); }
+            friend bool operator<( const Key& l, const elem_t& r) { return l < r.first; }
+            friend bool operator==(const Key& l, const elem_t& r) { return l == r.first; }
+            friend bool operator!=(const Key& l, const elem_t& r) { return !(l == r); }
         };
 
         vector_map() = default;

--- a/test/Verification_test.cpp
+++ b/test/Verification_test.cpp
@@ -137,3 +137,84 @@ BOOST_AUTO_TEST_CASE(Verification_negative_weight_test)
     BOOST_TEST(qYq != nullptr);
     BOOST_TEST(qYq->second == -2);
 }
+
+BOOST_AUTO_TEST_CASE(Verification_poststar_pop_test)
+{
+    std::istringstream pda_stream(R"({
+      "pda": {
+        "states": {
+          "p": { "X": {"to":"p", "pop":""} }
+        }
+      }
+    })");
+    auto pda = PdaJSONParser::parse<weight<void>,true>(pda_stream, std::cerr);
+    auto p_automaton_i = PAutomatonParser::parse_string("< [p] , [X] [X] >", pda);
+    auto p_automaton_f = PAutomatonParser::parse_string("< [p] , [X] >", pda);
+    PAutomatonProduct instance(pda, std::move(p_automaton_i), std::move(p_automaton_f));
+
+    auto result = Solver::post_star_accepts(instance);
+    BOOST_TEST(result);
+
+    auto trace = Solver::get_trace(instance);
+    BOOST_CHECK_EQUAL(trace.size(), 2);
+    BOOST_CHECK_EQUAL(trace[0]._stack.size(), 2);
+    BOOST_CHECK_EQUAL(trace[1]._stack.size(), 1);
+
+    std::stringstream s;
+    print_trace(trace, pda, s);
+    BOOST_TEST_MESSAGE(s.str());
+}
+
+BOOST_AUTO_TEST_CASE(Verification_poststar_empty_final_stack_test)
+{
+    std::istringstream pda_stream(R"({
+      "pda": {
+        "states": {
+          "p": { "X": {"to":"p", "pop":""} }
+        }
+      }
+    })");
+    auto pda = PdaJSONParser::parse<weight<void>,true>(pda_stream, std::cerr);
+    auto p_automaton_i = PAutomatonParser::parse_string("< [p] , [X] >", pda);
+    auto p_automaton_f = PAutomatonParser::parse_string("< [p] , >", pda);
+    PAutomatonProduct instance(pda, std::move(p_automaton_i), std::move(p_automaton_f));
+
+    auto result = Solver::post_star_accepts(instance);
+    BOOST_TEST(result);
+
+    auto trace = Solver::get_trace(instance);
+    BOOST_CHECK_EQUAL(trace.size(), 2);
+    BOOST_CHECK_EQUAL(trace[0]._stack.size(), 1);
+    BOOST_CHECK_EQUAL(trace[1]._stack.size(), 0);
+
+    std::stringstream s;
+    print_trace(trace, pda, s);
+    BOOST_TEST_MESSAGE(s.str());
+}
+
+BOOST_AUTO_TEST_CASE(Verification_poststar_no_ET_empty_final_stack_test)
+{
+    std::istringstream pda_stream(R"({
+      "pda": {
+        "states": {
+          "p": { "X": {"to":"p", "pop":""} }
+        }
+      }
+    })");
+    auto pda = PdaJSONParser::parse<weight<void>,true>(pda_stream, std::cerr);
+    auto p_automaton_i = PAutomatonParser::parse_string("< [p] , [X] >", pda);
+    auto p_automaton_f = PAutomatonParser::parse_string("< [p] , >", pda);
+    PAutomatonProduct instance(pda, std::move(p_automaton_i), std::move(p_automaton_f));
+
+    auto result = Solver::post_star_accepts_no_ET(instance);
+    BOOST_TEST(result);
+
+    auto trace = Solver::get_trace(instance);
+    BOOST_CHECK_EQUAL(trace.size(), 2);
+    BOOST_CHECK_EQUAL(trace[0]._stack.size(), 1);
+    BOOST_CHECK_EQUAL(trace[1]._stack.size(), 0);
+
+    std::stringstream s;
+    print_trace(trace, pda, s);
+    BOOST_TEST_MESSAGE(s.str());
+}


### PR DESCRIPTION
Fixes an edge case bug when using post* and final stack is empty. 
A bit annoying to do all this change for just that case, but we prioritise that it works in all cases.